### PR TITLE
Trim extra "," from URL.

### DIFF
--- a/image-slicing.el
+++ b/image-slicing.el
@@ -285,7 +285,7 @@ This function is installed on `post-command-hook'."
 
 (defun image-slicing-tag-img (dom &optional url)
   "Parse img DOM."
-    (let ((url (shr-expand-url (or url (shr--preferred-image dom)))))
+    (let ((url (string-trim-right (shr-expand-url (or url (shr--preferred-image dom))) ",")))
       (when (not (string-prefix-p "http" url))
         (setq url (concat "https:" url)))
       (insert (format "[[%s]]" url))))


### PR DESCRIPTION
For some websites, for example emacs-china.org, `(shr--preferred-image dom)` may return a URL with an extra ",".

I think this may be a bug in the shr package (https://github.com/emacs-mirror/emacs/blob/master/lisp/net/shr.el#L2020), and I believe it would be better if `image-slice` could trim trailing "," as a workaround...

终于搞明白为啥有时候访问 emacs china 会看到很多图片无法显示了。。。