### PR TITLE
eww: add "referer" to http request header.

### DIFF
--- a/image-slicing.el
+++ b/image-slicing.el
@@ -123,6 +123,10 @@ Otherwise, just run the CALLBACK function only."
            (funcall callback temp-image-file))
          image-src
          "-s"
+         ;; request might be denied by some servers without referer section in http header.
+         (if (equal major-mode 'eww-mode)
+             (concat "-e " (plist-get eww-data :url))
+           "")
          "-o"
          temp-image-file)
       (funcall callback image-src))))


### PR DESCRIPTION
Request might be denied by some servers without this.

例如少数派： https://sspai.com/post/95178

该网页的图片形如 `https://cdnfile.sspai.com/2024/11/24/article/85986585762d1999924f87e7649c6484.png?imageView2/2/w/1120/q/40/interlace/1/ignore-error/1`

如果不在 http request header 中包含 `Refer` ， 会返回 403 错误：


``` text
➤ ~/.dot-files [master] $ curl 'https://cdnfile.sspai.com/2024/11/24/article/85986585762d1999924f87e7649c6484.png?imageView2/2/w/1120/q/40/interlace/1/ignore-error/1'
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html>
<head><title>403 Forbidden</title></head>
<body>
<center><h1>403 Forbidden</h1></center>
</body>
</html>
➤ ~/.dot-files [master] $ curl -e 'https://sspai.com/post/95178' 'https://cdnfile.sspai.com/2024/11/24/article/85986585762d1999924f87e7649c6484.png?imageView2/2/w/1120/q/40/interlace/1/ignore-error/1' -o ~/tmp/a.png
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  480k  100  480k    0     0  2617k      0 --:--:-- --:--:-- --:--:-- 2623k
➤ ~/.dot-files [master] $ file ~/tmp/a.png
/home/yyc/tmp/a.png: PNG image data, 1080 x 611, 8-bit/color RGBA, non-interlaced
```

