### PR TITLE
Miscellaneous changes

### DIFF
--- a/README.org
+++ b/README.org
@@ -67,7 +67,7 @@ Here are a few variables that can be used for configuration:
 image-slice can also work with elfeed:
 
 #+begin_src emacs-lisp -r
-  ;; to to shr-external-rendering-functions (skip if alread setup for eww)
+  ;; add to shr-external-rendering-functions (skip if alread setup for eww)
   (add-to-list 'shr-external-rendering-functions
                '(img . image-slicing-tag-img))
 


### PR DESCRIPTION
1. make links & overlays buffer local 
   so buffers & processes can be killed, this could be done automatically, like:
   ```emacs-lisp
   (defadvice! :before '(quit-window elfeed-kill-buffer) yc/clear-curls-a (&rest _) 
       "Clear curl buffers before quit." 
       (when image-slicing-mode (image-slicing-clear))) 
   ```

2. Download then check file type just before displaying image. 
   Extension of images may not always match its mime-type...
   e.g. https://emacs-china.org/t/neovim-blink-cmp/28601

3. use image cache when exists

4. advice to `shr-image-tag` to enable image-slicing 
   So we can fallback to `shr-image-tag` for unsupported protocols (data, cid, et.al)

5. flush cache after (image-size) don't know why memory usage keeps increasing without this...

6. Adjust arguments for curl, and make curl-args customizable 
   1) Set user-agent properly `--user-agent` (e.g download fails for segmentfault.com without UA) 
   2) Follow new location with `-L`

7. display indicator in fringe for all modes when `image-slicing-mode` is t