### PR TITLE
prevent inserting an extra newline after printing all slices of image

### DIFF
--- a/image-slicing.el
+++ b/image-slicing.el
@@ -213,9 +213,12 @@ If BEFORE-STRING or AFTER-STRING not nil, put overlay before-string or
            (unless line-beginning-p
              (image-slicing-display begin (1+ begin) "" buffer new-line-str)
              (setq begin (1+ begin)))
-           (dolist (image (image-slicing-slice image (- end begin 1)))
-             (image-slicing-display begin (1+ begin) image buffer nil new-line-str)
-             (setq begin (1+ begin)))
+	   (let* ((images (image-slicing-slice image (- end begin 1)))
+		  (len (length images)))
+	     (dotimes (i len)
+	       (image-slicing-display begin (1+ begin) (nth i images) buffer nil
+				      (when (/= i (1- len)) new-line-str))
+	       (setq begin (1+ begin))))
            (image-slicing-display begin end "" buffer)
            (plist-put image-file-info :status "finished")))))))
 

--- a/image-slicing.el
+++ b/image-slicing.el
@@ -65,6 +65,11 @@
   :group 'image-slicing
   :type 'number)
 
+(defcustom image-slicing-newline-trailing-text t
+  "Enables putting text trailing an image link on a new line."
+  :group 'image-slicing
+  :type 'boolean)
+
 (defcustom image-slicing-curl-args
   '("-s" "-L"
     ;; some server returns error unless user-agent is set to modern browser, e.g. segmentfault.com
@@ -217,7 +222,9 @@ If BEFORE-STRING or AFTER-STRING not nil, put overlay before-string or
 		  (len (length images)))
 	     (dotimes (i len)
 	       (image-slicing-display begin (1+ begin) (nth i images) buffer nil
-				      (when (/= i (1- len)) new-line-str))
+				      (when (or image-slicing-newline-trailing-text
+						(/= i (1- len)))
+					new-line-str))
 	       (setq begin (1+ begin))))
            (image-slicing-display begin end "" buffer)
            (plist-put image-file-info :status "finished")))))))


### PR DESCRIPTION
I noticed that when `image-slicing-mode` is enabled, there is an extra newline that is shown at the bottom of the image, which isn't there when using the original `org-toggle-inline-images`. I modified a bit of code so that when printing every slice, on the very last slice, it passes `nil` for the `AFTER-STRING` arg of `image-slicing-display`, instead of the usual `(propertize "\n" 'face 'default 'line-height t)`. I've only tested this change on org-mode, so I'm not sure how this change would affect the functionality on EWW or Elfeed.